### PR TITLE
Add support for De Dietrich MPX boiler

### DIFF
--- a/custom_components/bdr_thermostat/config_schema.py
+++ b/custom_components/bdr_thermostat/config_schema.py
@@ -22,4 +22,4 @@ CLIMATE_SCHEMA = {
     vol.Required(
         CONF_BRAND,
         default="baxi",
-    ): vol.In(["baxi", "remeha"])}
+    ): vol.In(["baxi", "remeha", "dedietrich"])}

--- a/custom_components/bdr_thermostat/sensor.py
+++ b/custom_components/bdr_thermostat/sensor.py
@@ -206,7 +206,7 @@ class OutsideTemperatureSensor(SensorEntity):
     
         status = await self._bdr_api.get_status()
 
-        if status:
+        if status and status.get("outsideTemperature"):
             self._attr_native_value = status["outsideTemperature"]["value"]          
             self._attr_native_unit_of_measurement = status["outsideTemperature"]["unit"]
      


### PR DESCRIPTION
When setting up Smart TC app on my phone I noticed that the authentication endpoint is https://remoteapp.bdrthermea.com/user/dedietrich/activate which was missing in the component options, adding this to the available options was enough to successfully authenticate.

Also my boiler does not have an outside temperature sensor and Home Assistant was failing setting up the component in `OutsideTemperatureSensor` so I added the check whether the value has been sent in the payload.

With these two changes I am able to control my boiler. Thank you for this custom component!