### PR TITLE
Getting status when uri is not provided in capabilties

### DIFF
--- a/custom_components/bdr_thermostat/BdrAPI.py
+++ b/custom_components/bdr_thermostat/BdrAPI.py
@@ -192,7 +192,10 @@ class BdrAPI:
         return self._bootstraped
 
     async def get_status(self):
-        api_endpoint = self.capabilities["centralHeatingZones"]["statusUri"]
+        if self.capabilities["centralHeatingZones"].get("statusUri"):
+            api_endpoint = self.capabilities["centralHeatingZones"]["statusUri"]
+        else:
+            api_endpoint = self.capabilities["centralHeatingZones"]["uri"] + "/status"
 
         return await self.async_get_request(api_endpoint)
 


### PR DESCRIPTION
I have made a nodejs port for Homey. In this port there was een issue that the status url was not pressent in capabilities. But a user reported that a call to status was still succesfull. I fixed it in my Homey port, but it can also be done for your HA implementation. I made a sugestion in this PR, but it is **untested**. I don't have HA running atm.