### PR TITLE
Fix for integration not working in 2023.5

### DIFF
--- a/custom_components/bdr_thermostat/__init__.py
+++ b/custom_components/bdr_thermostat/__init__.py
@@ -59,8 +59,7 @@ async def async_setup_entry(hass, config_entry):
     await api.bootstrap()
     hass.data[PLATFORM] = {DATA_KEY_API: api, DATA_KEY_CONFIG: config_entry.data}
     register_device(hass, config_entry, api.get_device_information())
-    hass.config_entries.async_setup_platforms(config_entry, PLATFORMS)
-
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
     return True
 
 


### PR DESCRIPTION
Simple change because the integration was not loading due to: https://developers.home-assistant.io/blog/2022/07/08/config_entry_forwards/